### PR TITLE
Add assert statements

### DIFF
--- a/src/main/java/neo/MarkCommand.java
+++ b/src/main/java/neo/MarkCommand.java
@@ -32,7 +32,7 @@ public class MarkCommand extends Command {
     @Override
     String complete(String tempi) throws NeoException, IOException {
         int tempii = Integer.valueOf(tempi);
-        System.out.println(arrayLL.getTask(0));
+        assert arrayLL.getTask(tempii-1).getIsDone() == " ": "already marked";
         arrayLL.getTask(tempii-1).setIsDone(true);
         //System.out.println("Nice! I've marked this task as done");
         //System.out.println(arrayLL.getTask(tempii-1).toString());

--- a/src/main/java/neo/Parser.java
+++ b/src/main/java/neo/Parser.java
@@ -44,6 +44,7 @@ public class Parser {
         }
         String arr[];
         arr = userText.split(" ", 2);
+        assert arr.length >= 2: "array length is less than 2";
         if (arr.length>1 && arr[0].equals("mark")){
             this.mark = new MarkCommand(ui, stor, arrayLL);
             return mark.complete(arr[1]);

--- a/src/main/java/neo/UnMarkCommand.java
+++ b/src/main/java/neo/UnMarkCommand.java
@@ -35,6 +35,7 @@ public class UnMarkCommand extends Command{
     @Override
     String complete(String tempi) throws NeoException, IOException {
         int tempii = Integer.valueOf(tempi);
+        assert arrayLL.getTask(tempii-1).getIsDone() == "X": "already unmarked";
         arrayLL.getTask(tempii-1).setIsDone(false);
         //System.out.println("ohk I've marked this task as not done");
         //System.out.println(arrayLL.getTask(tempii-1).toString());


### PR DESCRIPTION
Under parser class, the checkText method uses an array to store elements of a string after splitting. An assumption is made that the array has more than one element. Complete method in mark and unmark commands don't check if the command has already been marked.

This might lead to error if assumptions made are not true.

Let us add assert statements to avoid possible bugs that can arise from these assumptions.